### PR TITLE
Fix Makefile not finding GIO libs on certain systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PKG_CONFIG = pkg-config
 
-CFLAGS=-std=c99 -Wall -Wextra -O2 `$(PKG_CONFIG) --cflags gio-2.0 gio-unix-2.0 glib-2.0 mpv`
-LDFLAGS=`$(PKG_CONFIG) --libs gio-2.0 gio-unix-2.0 glib-2.0`
+CFLAGS=-std=c99 -Wall -Wextra -O2 `$(PKG_CONFIG) --cflags --libs gio-2.0 gio-unix-2.0 glib-2.0 mpv`
+LDFLAGS=`$(PKG_CONFIG) --cflags --libs gio-2.0 gio-unix-2.0 glib-2.0`
 
 mpris.so: mpris.c
 	$(CC) mpris.c -o mpris.so $(CFLAGS) $(LDFLAGS) -shared -fPIC


### PR DESCRIPTION
When I tried to compile `mpv-mpris` on my Gentoo machine, it couldn't
find the directory where GIO was stored, so to fix this issue, I have
modified the Makefile to supply `--cflags` to `pkg-config`, which
supplies the path to look for the GIO libraries.

Because of the success of this fix, I am submitting it as a PR to
resolve build problems that may occur in the future without this fix.