### PR TITLE
Makefile: Allow user to append to CFLAGS and LDFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 PKG_CONFIG = pkg-config
 
-CFLAGS=-std=c99 -Wall -Wextra -O2 `$(PKG_CONFIG) --cflags gio-2.0 gio-unix-2.0 glib-2.0 mpv`
-LDFLAGS=`$(PKG_CONFIG) --libs gio-2.0 gio-unix-2.0 glib-2.0`
+BASE_CFLAGS=-std=c99 -Wall -Wextra -O2 `$(PKG_CONFIG) --cflags gio-2.0 gio-unix-2.0 glib-2.0 mpv`
+BASE_LDFLAGS=`$(PKG_CONFIG) --libs gio-2.0 gio-unix-2.0 glib-2.0`
 
 mpris.so: mpris.c
-	$(CC) mpris.c -o mpris.so $(CFLAGS) $(LDFLAGS) -shared -fPIC
+	$(CC) mpris.c -o mpris.so $(BASE_CFLAGS) $(CFLAGS) $(BASE_LDFLAGS) $(LDFLAGS) -shared -fPIC
 
 install: mpris.so
 	mkdir -p $(HOME)/.config/mpv/scripts


### PR DESCRIPTION
That's needed to allow distro packaging tools (or the user)
to override CFLAGS such as optimization level, march,
activate debug symbols etc.

Note: I'll try to get this package in Gentoo as proxy maintainer :wink:. 