### PR TITLE
Remove implicit declaration warning

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -2,6 +2,7 @@
 #include <glib-unix.h>
 #include <mpv/client.h>
 #include <inttypes.h>
+#include <string.h>
 
 static const char *introspection_xml =
     "<node>\n"


### PR DESCRIPTION
I'm seeing this with gcc 7:
```
mpris.c: In function 'add_metadata_content_created':
mpris.c:278:9: warning: implicit declaration of function 'strlen' [-Wimplicit-function-declaration]
     if (strlen(date) == 4) {
         ^~~~~~
mpris.c:278:9: warning: incompatible implicit declaration of built-in function 'strlen'
mpris.c:278:9: note: include '<string.h>' or provide a declaration of 'strlen'
```