### PR TITLE
Do not queue on initial name request

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -936,7 +936,7 @@ int mpv_open_cplugin(mpv_handle *mpv)
 
     ud.bus_id = g_bus_own_name(G_BUS_TYPE_SESSION,
                                "org.mpris.MediaPlayer2.mpv",
-                               G_BUS_NAME_OWNER_FLAGS_NONE,
+                               G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
                                on_bus_acquired,
                                NULL,
                                on_name_lost,


### PR DESCRIPTION
The name lost handler runs when the name cannot be acquired because
another application is using it, presumably another instance of
mpv-mpris. By default, this puts mpv-mpris into a queue for the name.
When the other name becomes available, mpv-mpris will then acquire it
and own both names which is a mistake.

Add the DO_NOT_QUEUE name flag to disable the queuing behavior to fix
this issue.