### PR TITLE
Fix YouTube regex including 0 to the numeric range

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -256,7 +256,7 @@ static void try_put_local_art(mpv_handle *mpv, GVariantDict *dict, char *path)
 }
 
 static const char *youtube_url_pattern =
-    "^https?:\\/\\/(?:youtu.be\\/|(?:www\\.)?youtube\\.com\\/watch\\?v=)(?<id>[a-zA-Z1-9_-]*)\\??.*";
+    "^https?:\\/\\/(?:youtu.be\\/|(?:www\\.)?youtube\\.com\\/watch\\?v=)(?<id>[a-zA-Z0-9_-]*)\\??.*";
 
 static GRegex *youtube_url_regex;
 


### PR DESCRIPTION
The thumbnail fetcher doesn't work for videos that the id contains `0`.

For example:

[this video](https://www.youtube.com/watch?v=QPZ0pIK_wsc) id is "QPZ0pIK_wsc" but in the metadata the artUrl is: https://i1.ytimg.com/vi/QPZ/hqdefault.jpg
Taking a look at the `try_put_youtube_thumbnail()` I saw that 0 isn't included in the regex numeric range: 
https://github.com/hoyon/mpv-mpris/blob/f1482350868bf20e4575f923943ec998469b255e/mpris.c#L259

After changing `1` to `0` (2eb5247a2a0ee8e69474b72e31d2b55c092faf96) the returned artUrl is https://i1.ytimg.com/vi/QPZ0pIK_wsc/hqdefault.jpg.