### PR TITLE
Fix loop-file and loop-playlist detection. 

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -859,12 +859,12 @@ static void handle_property_change(const char *name, void *data, UserData *ud)
 
     } else if (g_strcmp0(name, "loop-file") == 0) {
         char *status = *(char **)data;
-        if (g_strcmp0(status, "yes") == 0 || g_strcmp0(status, "inf") == 0) {
+        if (g_strcmp0(status, "no") == 1) {
             ud->loop_status = LOOP_TRACK;
         } else {
             char *playlist_status;
             mpv_get_property(ud->mpv, "loop-playlist", MPV_FORMAT_STRING, &playlist_status);
-            if (g_strcmp0(playlist_status, "inf") == 0) {
+            if (g_strcmp0(playlist_status, "no") == 1) {
                 ud->loop_status = LOOP_PLAYLIST;
             } else {
                 ud->loop_status = LOOP_NONE;
@@ -874,12 +874,12 @@ static void handle_property_change(const char *name, void *data, UserData *ud)
         prop_value = g_variant_new_string(ud->loop_status);
     } else if (g_strcmp0(name, "loop-playlist") == 0) {
         char *status = *(char **)data;
-        if (g_strcmp0(status, "inf") == 0) {
+        if (g_strcmp0(status, "no") == 1) {
             ud->loop_status = LOOP_PLAYLIST;
         } else {
             char *file_status;
             mpv_get_property(ud->mpv, "loop-file", MPV_FORMAT_STRING, &file_status);
-            if (g_strcmp0(file_status, "yes") == 0) {
+            if (g_strcmp0(file_status, "no") == 1) {
                 ud->loop_status = LOOP_TRACK;
             } else {
                 ud->loop_status = LOOP_NONE;


### PR DESCRIPTION
I was looking through the MPV docs while working on [my own plugin](https://github.com/StratusFearMe21/mpv-presence/blob/master/src/lib.rs) and found that the detection of whether looping on a file or looping on a playlist is turned on is flawed. These are the relevant docs for what I fixed
```
--loop-playlist=<N|inf|force|no>, --loop-playlist

    Loops playback N times. A value of 1 plays it one time (default), 2 two times, etc. inf means forever. no is the same as 1 and disables looping. If several files are specified on command line, the entire playlist is looped. --loop-playlist is the same as --loop-playlist=inf.

    The force mode is like inf, but does not skip playlist entries which have been marked as failing. This means the player might waste CPU time trying to loop a file that doesn't exist. But it might be useful for playing web radios under very bad network conditions.
--loop-file=<N|inf|no>, --loop=<N|inf|no>

    Loop a single file N times. inf means forever, no means normal playback. For compatibility, --loop-file and --loop-file=yes are also accepted, and are the same as --loop-file=inf.

    The difference to --loop-playlist is that this doesn't loop the playlist, just the file itself. If the playlist contains only a single file, the difference between the two option is that this option performs a seek on loop, instead of reloading the file.
```
For `loop-playlist` and `loop-file` you can either pass a number, or a string. This plugin does not take into account if the user has passed a number. In order to fix this, I made it so that a `loop-file` or `loop-playlist` are detected when the value is not explicitly `"no"`. This works since all other possible values that `loop-file` and `loop-playlist` can be suggests that it's turned on.

(I don't know C so my implementation may or may not be wrong)