### PR TITLE
Add smoke test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,11 @@ jobs:
           name: mpris.so
           path: mpris.so
           if-no-files-found: error
+
+      - name: Prepare for test
+        run: |
+          sudo apt install mpv playerctl sound-theme-freedesktop bash dbus xvfb xauth jq socat gawk
+
+      - name: Run tests
+        run: |
+          make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,19 @@ jobs:
       - name: Run tests
         run: |
           make test
+
+      - name: Check git files unmodified
+        run: |
+          git diff --exit-code HEAD
+
+      - name: Check .gitignore matches generated files
+        run: |
+          ! git ls-files --others --exclude-standard | grep .
+
+      - name: Cleanup generated files
+        run: |
+          make clean
+
+      - name: Check cleanup removed generated files
+        run: |
+          ! git ls-files --others | grep .

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 compile_commands.json
 mpris.so
+*.mpv.ipc.input.json
+*.mpv.ipc.output.json
+*.mpv.ipc
+*.mpv.log
+*.xvfb.log
+*.Xauthority
+*.socat.log
+*.exit-code.log
+*.stderr.log

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ SYS_SCRIPTS_DIR := /etc/mpv/scripts
 .PHONY: \
   install install-user install-system \
   uninstall uninstall-user uninstall-system \
+  test \
   clean
 
 mpris.so: mpris.c
@@ -51,5 +52,9 @@ uninstall-system:
 	$(RM) -f $(DESTDIR)$(PLUGINDIR)/mpris.so
 	$(RMDIR) -p $(DESTDIR)$(PLUGINDIR)
 
+test: mpris.so
+	$(MAKE) -C test
+
 clean:
 	rm -f mpris.so
+	$(MAKE) -C test clean

--- a/README.md
+++ b/README.md
@@ -47,6 +47,43 @@ Build requirements:
 
 Building should be as simple as running `make` in the source code directory.
 
+## Test
+
+Test requirements:
+ - mpv (for loading the mpv mpris plugin)
+ - mpv-mpris plugin (installed or self-built)
+ - playerctl (for sending MPRIS commands via D-Bus)
+ - sound-theme-freedesktop (for a file to play in mpv)
+ - bash (for running the test scripts)
+ - dbus-run-session (from dbus, for simulating a D-Bus session)
+ - xvfb and xauth (for simulating an X11 session)
+ - jq (for mpv IPC JSON generation and parsing)
+ - socat (for passing JSON to/from mpv IPC sockets)
+ - awk (for redirecting parts of mpv stderr logs)
+
+Testing should be as simple as running `make test` in the source code directory.
+
+The stderr of the tests will be empty unless there are mpv/etc issues.
+
+The tests accept these environment variables as parameters:
+ - `MPV_MPRIS_TEST_PLUGIN`: the mpv mpris plugin file to test, must be
+   readable and executable, defaults to the self-built one. Set it to an
+   empty string to only load and test an already installed mpv mpris plugin.
+ - `MPV_MPRIS_TEST_PLAY`: the file to play during tests, defaults to
+   `/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga`.
+   Use a file at most 10 seconds long or the tests will take a long time.
+ - `MPV_MPRIS_TEST_MPV_IPC`: dir for mpv IPC, default is test dir.
+ - `MPV_MPRIS_TEST_DBUS`: dir for D-Bus sockets, default is test dir.
+   Sets the `XDG_RUNTIME_DIR` env var so D-Bus uses the dir.
+ - `MPV_MPRIS_TEST_XAUTH`: dir for Xauthority files, default is test dir.
+ - `MPV_MPRIS_TEST_LOG`: dir for mpv/socat logs, default is test dir.
+ - `MPV_MPRIS_TEST_TMP`: dir for temp files, default is test dir.
+   Sets the `TEMPDIR`, `TMPDIR`, `TEMP` and `TMP` env vars.
+ - `MPV_MPRIS_TEST_NO_STDERR`: disable extra printing of the errors printed
+   to stderr. This is for when the test scenario already does this.
+
+These parameters are useful for running the tests in alternate test scenarios.
+
 ## D-Bus interfaces
 
 Implemented:

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,29 @@
+MAKEFLAGS += --output-sync=target
+
+tests = \
+	metadata \
+	pause \
+	play \
+	play-pause \
+	stop
+
+.PHONY: \
+	test \
+	$(tests) \
+	clean
+
+test: $(tests)
+
+$(tests):
+	./wrapper "$@"
+
+clean:
+	rm -f \
+	  *.mpv.ipc* \
+	  *.mpv.log \
+	  *.xvfb.log \
+	  *.Xauthority \
+	  *.socat.log \
+	  *.exit-code.log \
+	  *.stderr.log
+	rm -rf dbus-1

--- a/test/env
+++ b/test/env
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -e
+
+
+exec {BASH_XTRACEFD}>&1
+echo "$0" "$@"
+set -x
+
+
+test="$(basename "$1")"
+
+
+if [ -z "${MPV_MPRIS_TEST_PLUGIN+set}" ] ; then
+	export MPV_MPRIS_TEST_PLUGIN=../mpris.so
+fi
+
+if [ -z "$MPV_MPRIS_TEST_PLAY" ] ; then
+	export MPV_MPRIS_TEST_PLAY=/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga
+fi
+
+if [ -z "$MPV_MPRIS_TEST_MPV_IPC" ] ; then
+	export MPV_MPRIS_TEST_MPV_IPC=.
+fi
+
+if [ -z "$MPV_MPRIS_TEST_LOG" ] ; then
+	export MPV_MPRIS_TEST_LOG=.
+fi
+
+if [ -z "$MPV_MPRIS_TEST_DBUS" ] ; then
+	MPV_MPRIS_TEST_DBUS=.
+fi
+
+if [ -z "$MPV_MPRIS_TEST_XAUTH" ] ; then
+	MPV_MPRIS_TEST_XAUTH=.
+fi
+
+if [ -z "$MPV_MPRIS_TEST_TMP" ] ; then
+	MPV_MPRIS_TEST_TMP=.
+fi
+
+if [ -n "$MPV_MPRIS_TEST_PLUGIN" ] ; then
+	if [ ! -f "$MPV_MPRIS_TEST_PLUGIN" ] ||
+	   [ ! -r "$MPV_MPRIS_TEST_PLUGIN" ] ||
+	   [ ! -x "$MPV_MPRIS_TEST_PLUGIN" ] ; then
+		echo "$MPV_MPRIS_TEST_PLUGIN not an existing file with rx perms" >&2
+		exit 1
+	fi
+fi
+
+if [ ! -f "$MPV_MPRIS_TEST_PLAY" ] ||
+   [ ! -r "$MPV_MPRIS_TEST_PLAY" ] ; then
+	echo "$MPV_MPRIS_TEST_PLAY not an existing readable file" >&2
+	exit 1
+fi
+
+writable_dir () {
+	if [ ! -d "$1" ] ||
+	   [ ! -r "$1" ] ||
+	   [ ! -w "$1" ] ||
+	   [ ! -x "$1" ] ; then
+		echo "$1 not an existing writable directory" >&2
+		exit 1
+	fi
+}
+
+writable_dir "$MPV_MPRIS_TEST_MPV_IPC"
+writable_dir "$MPV_MPRIS_TEST_DBUS"
+writable_dir "$MPV_MPRIS_TEST_XAUTH"
+writable_dir "$MPV_MPRIS_TEST_LOG"
+writable_dir "$MPV_MPRIS_TEST_TMP"
+
+
+# These are not used outside this script so unexport them
+export -n \
+	MPV_MPRIS_TEST_DBUS \
+	MPV_MPRIS_TEST_XAUTH \
+	MPV_MPRIS_TEST_TMP
+
+
+# On some distros --auto-servernum doesn't work in parallel scenarios,
+# but --auto-display is offered and does work in parallel scenarios.
+# On other distros --auto-servernum *does* work in parallel scenarios,
+# but --auto-display is not offered so cannot work at all.
+# Detect which xvfb-run we have and use the right option.
+if xvfb-run --help | grep -- --auto-display ; then
+	xvfb_auto=--auto-display
+else
+	xvfb_auto=--auto-servernum
+fi
+
+
+# xvfb-run -f is --auth-file, but that does not work on some distros:
+# https://bugs.archlinux.org/task/73865
+exec \
+env \
+MPV_MPRIS_TEST_NAME="$test" \
+XDG_RUNTIME_DIR="$MPV_MPRIS_TEST_DBUS" \
+TEMPDIR="$MPV_MPRIS_TEST_TMP" \
+TMPDIR="$MPV_MPRIS_TEST_TMP" \
+TEMP="$MPV_MPRIS_TEST_TMP" \
+TMP="$MPV_MPRIS_TEST_TMP" \
+dbus-run-session -- \
+xvfb-run "$xvfb_auto" --error-file "$MPV_MPRIS_TEST_LOG/$test.xvfb.log" -f "$MPV_MPRIS_TEST_XAUTH/$test.Xauthority" \
+"$@"

--- a/test/metadata
+++ b/test/metadata
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+. ./setup
+
+test "$(playerctl metadata xesam:url)" = "file://$file"
+
+# Wait for mpv to parse the title from the file
+sleep 2
+
+test "$(playerctl metadata xesam:title)" != ""
+
+wait %1

--- a/test/pause
+++ b/test/pause
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+. ./setup
+
+status Playing
+check pause false
+
+playerctl pause
+sleep 1
+
+status Paused
+check pause true
+
+playerctl play
+sleep 1
+
+wait %1

--- a/test/play
+++ b/test/play
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+pause=1
+
+. ./setup
+
+status Paused
+check pause true
+
+playerctl play
+sleep 1
+
+status Playing
+check pause false
+
+wait %1

--- a/test/play-pause
+++ b/test/play-pause
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+pause=1
+
+. ./setup
+
+status Paused
+check pause true
+
+playerctl play-pause
+sleep 1
+
+status Playing
+check pause false
+
+playerctl play-pause
+sleep 1
+
+status Paused
+check pause true
+
+playerctl play-pause
+sleep 1
+
+status Playing
+check pause false
+
+wait %1

--- a/test/setup
+++ b/test/setup
@@ -1,0 +1,94 @@
+set -e
+
+
+exec {BASH_XTRACEFD}>&1
+echo "$0" "$@"
+set -x
+
+
+test -n "$MPV_MPRIS_TEST_NAME" ||
+exec "./env" "$0" "$@"
+
+
+test="$(basename "$0")"
+
+
+if [ "$test" = setup ] ; then
+	echo "This setup script should be sourced, not executed" >&2
+	exit 1
+fi
+
+
+input_json="$MPV_MPRIS_TEST_MPV_IPC/$test.mpv.ipc.input.json"
+output_json="$MPV_MPRIS_TEST_MPV_IPC/$test.mpv.ipc.output.json"
+ipc="$MPV_MPRIS_TEST_MPV_IPC/$test.mpv.ipc"
+log_prefix="$MPV_MPRIS_TEST_LOG/$test"
+mpv_log="$log_prefix.mpv.log"
+socat_log="$log_prefix.socat.log"
+file="$MPV_MPRIS_TEST_PLAY"
+
+
+prop () {
+	jq --null-input --compact-output --arg prop "$1" '{command: ["get_property", $prop]}'
+}
+
+val () {
+	jq --exit-status --null-input "inputs // {} | try (.data == $1 and .error == \"success\") catch false"
+}
+
+check () {
+	prop "$1" > "$input_json"
+	cat "$input_json"
+	rm -f "$socat_log"
+	# Pass the input JSON to socat and save the output JSON, also redirect
+	# socat errors to a file so we can check afterward if there are errors.
+	< "$input_json" socat -lf"$socat_log" - "$ipc" > "$output_json"
+	cat "$socat_log" >&2
+	test ! -s "$socat_log"
+	cat "$output_json"
+	test -s "$output_json"
+	< "$output_json" val "$2"
+}
+
+status () {
+	playerctl status |
+	grep "^$1$"
+}
+
+
+params=()
+if [ -n "$pause" ] && [ "$pause" -ne 0 ] 2> /dev/null ; then
+	params+=("--pause")
+fi
+
+if [ -n "$MPV_MPRIS_TEST_PLUGIN" ] ; then
+	params+=("--load-scripts=no" "--script=$MPV_MPRIS_TEST_PLUGIN")
+fi
+
+
+unset \
+	MPV_MPRIS_TEST_PLUGIN \
+	MPV_MPRIS_TEST_PLAY \
+	MPV_MPRIS_TEST_MPV_IPC \
+	MPV_MPRIS_TEST_LOG
+
+
+echo "DISPLAY=$DISPLAY"
+echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+
+
+mpv \
+"${params[@]}" \
+--vo=null --ao=null \
+--msg-time \
+--msg-module \
+--msg-level=cplayer=trace,mpris=trace \
+--log-file="$mpv_log" \
+--input-ipc-server="$ipc" \
+"$file" \
+2> >(awk '/statusline.*Paused/{print>"/dev/stdout";next} 1')>&2 \
+&
+
+
+# Wait for mpv to start up and load the file
+sleep 2

--- a/test/stop
+++ b/test/stop
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+pause=1
+
+. ./setup
+
+status Paused
+check pause true
+
+playerctl stop
+sleep 2
+
+ret_ipc=0
+prop pause > "$input_json"
+cat "$input_json"
+rm -f "$socat_log"
+# Since mpv should be stopped by now and the IPC socket closed by mpv,
+# an error from socat is expected, so redirect it to a log file so that
+# it doesn't hit stderr, as some test systems check that stderr is empty.
+< "$input_json" socat -lf"$socat_log" - "$ipc" > "$output_json" ||
+ret_ipc=$?
+cat "$output_json"
+test ! -s "$output_json"
+
+if [ $ret_ipc -eq 0 ] ; then
+	echo 'socat succeeded but it should have failed!' >&2
+	echo 'probably mpv did not stop when asked to!' >&2
+fi
+
+if [ ! -s "$socat_log" ] ; then
+	echo 'socat log should contain an error!' >&2
+else
+	echo 'socat log contains these *expected* errors:'
+	cat "$socat_log"
+fi
+
+playerctl status 2>&1 > /dev/null |
+grep '^No players found$'
+
+if [ $ret_ipc -eq 0 ] || [ ! -s "$socat_log" ] ; then
+	exit 1
+fi

--- a/test/wrapper
+++ b/test/wrapper
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -e
+
+
+if [ -z "$MPV_MPRIS_TEST_LOG" ] ; then
+        MPV_MPRIS_TEST_LOG=.
+fi
+
+
+test="$1"
+exit_code="$MPV_MPRIS_TEST_LOG/$test.exit-code.log"
+stderr="$MPV_MPRIS_TEST_LOG/$test.stderr.log"
+
+
+rm -f "$exit_code" "$stderr"
+
+
+# This construct directs stderr to what it currently is
+# but also sends it to a file for checking afterwards
+# and also saves the exit code to a file for checking.
+exec 3>&1
+{
+	ret=0
+	"./$test" 2>&1 >&3 ||
+	ret=$?
+	echo "$ret" > "$exit_code"
+} |
+tee "$stderr"
+
+
+< "$exit_code" read -r ret
+
+
+if [ -s "$stderr" ] ; then
+	if [ -z "$MPV_MPRIS_TEST_NO_STDERR" ] ; then
+		echo "test $test: stderr not empty!" >&2
+		echo "test $test: start of stderr ---------------------" >&2
+		cat "$stderr" >&2
+		echo "test $test: end of stderr -----------------------" >&2
+	fi
+	echo "test $test: stderr not empty!" >&2
+fi
+
+if [ "$ret" -ne 0 ] ; then
+	echo "test $test: failed with exit code $ret" >&2
+fi
+
+
+if [ "$ret" -ne 0 ] ; then
+	 exit "$ret"
+fi
+
+if [ -s "$stderr" ] ; then
+	 exit 1
+fi


### PR DESCRIPTION
Uses mpv, mpv-mpris, playerctl, sound-theme-freedesktop, bash,
dbus-run-session, xvfb, xauth, jo, jq, socat and awk.

Initial tests include checking metadata, pausing a playing mpv, playing a
paused mpv, toggling mpv between playing and pausing, stopping a playing mpv.

Add enough parameters to make it flexible and useful for testing already
installed mpv mpris plugins, which will primarily be useful for distros.

Document the test requirements and parameters in the README.md file.

Should help prevent breakage and ensure mpv compatibility.

This has been adapted from the Debian autopkgtests that I wrote:

https://sources.debian.org/src/mpv-mpris/unstable/debian/tests/