### PR TITLE
Add C preprocessor flags to the compiler command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SYS_SCRIPTS_DIR := /etc/mpv/scripts
   clean
 
 mpris.so: mpris.c
-	$(CC) mpris.c -o mpris.so $(CFLAGS) $(LDFLAGS) -shared -fPIC
+	$(CC) mpris.c -o mpris.so $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -fPIC
 
 ifneq ($(shell id -u),0)
 install: install-user


### PR DESCRIPTION
These are often used by distros to add hardening/reproducibility flags.