### PR TITLE
Remove files created by the tests before the tests start

### DIFF
--- a/test/env
+++ b/test/env
@@ -90,6 +90,9 @@ else
 fi
 
 
+rm -f "$MPV_MPRIS_TEST_LOG/$test.xvfb.log" "$MPV_MPRIS_TEST_XAUTH/$test.Xauthority"
+
+
 # xvfb-run -f is --auth-file, but that does not work on some distros:
 # https://bugs.archlinux.org/task/73865
 exec \

--- a/test/setup
+++ b/test/setup
@@ -77,6 +77,9 @@ echo "DISPLAY=$DISPLAY"
 echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
 
 
+rm -f "$ipc" "$mpv_log" "$socat_log"
+
+
 mpv \
 "${params[@]}" \
 --vo=null --ao=null \


### PR DESCRIPTION
Ensures that everything is newly created by the tests with no extra data.
