### PR TITLE
Add compatibility with old versions of playerctl

### DIFF
--- a/test/stop
+++ b/test/stop
@@ -28,7 +28,7 @@ if [ $ret_ipc -eq 0 ] ; then
 fi
 
 playerctl status 2>&1 > /dev/null |
-grep '^No players found$'
+grep "^No players \(were \)\?found$"
 
 if [ $ret_ipc -eq 0 ] ; then
 	exit 1


### PR DESCRIPTION
playerctl version 2.0.0 rc1 changed the message when no players are found.

See-also: https://github.com/altdesktop/playerctl/commit/ee50b0da927ac6b33fb84f75c9acd35b40c23d0d
