### PR TITLE
Tell socat that the mpv IPC socket is a Unix socket

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -42,7 +42,7 @@ check () {
 	rm -f "$socat_log"
 	# Pass the input JSON to socat and save the output JSON, also redirect
 	# socat errors to a file so we can check afterward if there are errors.
-	< "$input_json" socat -lf"$socat_log" - "$ipc" > "$output_json"
+	< "$input_json" socat -lf"$socat_log" - "UNIX-CONNECT:$ipc" > "$output_json"
 	cat "$socat_log" >&2
 	test ! -s "$socat_log"
 	cat "$output_json"

--- a/test/stop
+++ b/test/stop
@@ -21,7 +21,7 @@ rm -f "$socat_log"
 # Since mpv should be stopped by now and the IPC socket closed by mpv,
 # an error from socat is expected, so redirect it to a log file so that
 # it doesn't hit stderr, as some test systems check that stderr is empty.
-< "$input_json" socat -lf"$socat_log" - "$ipc" > "$output_json" ||
+< "$input_json" socat -lf"$socat_log" - "UNIX-CONNECT:$ipc" > "$output_json" ||
 ret_ipc=$?
 cat "$output_json"
 test ! -s "$output_json"


### PR DESCRIPTION
When an argument doesn't contain a slash the argument won't be interpreted
as a filename and so the socket detection will not happen.

```
E unknown device/address "stop.mpv.ipc"
```
