### PR TITLE
Ensure that the D-Bus directory for tests has suitable permissions

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -27,4 +27,4 @@ clean:
 	  *.socat.log \
 	  *.exit-code.log \
 	  *.stderr.log
-	rm -rf dbus-1
+	rm -rf dbus

--- a/test/env
+++ b/test/env
@@ -71,6 +71,10 @@ writable_dir "$MPV_MPRIS_TEST_LOG"
 writable_dir "$MPV_MPRIS_TEST_TMP"
 
 
+MPV_MPRIS_TEST_DBUS="$MPV_MPRIS_TEST_DBUS/dbus"
+mkdir -p -m 0700 "$MPV_MPRIS_TEST_DBUS"
+
+
 # These are not used outside this script so unexport them
 export -n \
 	MPV_MPRIS_TEST_DBUS \


### PR DESCRIPTION
The D-Bus directory must not be writable by other users:

  dbus: Unable to set up transient service directory: XDG_RUNTIME_DIR "." can be written by others (mode 040775)

Fixes test failure when building with less restrictive umask 0002.

Detected-by: Reproducible Builds <https://reproducible-builds.org/>
See-also: https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/mpv-mpris.html
