### PR TITLE
Always use org.mpris.MediaPlayer2.mpv.instanceXXX name

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -988,8 +988,10 @@ int mpv_open_cplugin(mpv_handle *mpv)
     ud.changed_properties = g_hash_table_new(g_str_hash, g_str_equal);
     ud.seek_expected = FALSE;
 
+    pid_t pid = getpid();
+    char *name = g_strdup_printf("org.mpris.MediaPlayer2.mpv.instance%d", pid);
     ud.bus_id = g_bus_own_name(G_BUS_TYPE_SESSION,
-                               "org.mpris.MediaPlayer2.mpv",
+                               name,
                                G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
                                on_bus_acquired,
                                NULL,


### PR DESCRIPTION
It's more predictable for people (like me) who want to control a specific instance of MPV.