### PR TITLE
Fix Unknown Artist for YouTube videos

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -360,7 +360,7 @@ static GVariant *create_metadata(UserData *ud)
     add_metadata_item_string(ud->mpv, &dict, "metadata/by-key/Album", "xesam:album");
     add_metadata_item_string(ud->mpv, &dict, "metadata/by-key/Genre", "xesam:genre");
 
-    add_metadata_item_string(ud->mpv, &dict, "metadata/by-key/uploader", "xesam:artist");
+    add_metadata_item_string_list(ud->mpv, &dict, "metadata/by-key/uploader", "xesam:artist");
     add_metadata_item_string_list(ud->mpv, &dict, "metadata/by-key/Artist", "xesam:artist");
     add_metadata_item_string_list(ud->mpv, &dict, "metadata/by-key/Album_Artist", "xesam:albumArtist");
     add_metadata_item_string_list(ud->mpv, &dict, "metadata/by-key/Composer", "xesam:composer");


### PR DESCRIPTION
According to MPRIS protocol, `xesam:artist` is a list of strings and not string and thus, when a youtube video is played in mpv, GNOME shell says `Received faulty track artist metadata from org.mpris.MediaPlayer2.mpv; expected an array of strings, got <artistname> (string)`

So just changed `add_metadata_item_string` to `add_metadata_item_string_list` and it works fine when I tested.
