### PR TITLE
makefile: Remove backticks and use explicit shell function call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ RMDIR := rmdir
 LN := ln
 RM := rm
 
-CFLAGS += -std=c99 -Wall -Wextra -O2 -pedantic `$(PKG_CONFIG) --cflags gio-2.0 gio-unix-2.0 glib-2.0 mpv`
-LDFLAGS += `$(PKG_CONFIG) --libs gio-2.0 gio-unix-2.0 glib-2.0`
+CFLAGS += -std=c99 -Wall -Wextra -O2 -pedantic $(shell $(PKG_CONFIG) --cflags gio-2.0 gio-unix-2.0 glib-2.0 mpv)
+LDFLAGS += $(shell $(PKG_CONFIG) --libs gio-2.0 gio-unix-2.0 glib-2.0)
 
 SCRIPTS_DIR := $(HOME)/.config/mpv/scripts
 


### PR DESCRIPTION
This allows the pkg-config to be evaluated before it is printed,
and so the output of make is more debuggable.

(This also fixes the build on alpine.)