### PR TITLE
Fix test failure with glib 2.73.3

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -63,8 +63,10 @@ wait_for () {
 }
 
 playerctl_list_all_is_mpv () {
-	player="$(playerctl --list-all 2>&1)"
-	test "$player" = mpv
+	ret=0 ; player="$(playerctl --list-all 2> /dev/null)" || ret=$?
+	if [ $ret -ne 0 ] || [ "$player" != mpv ] ; then
+		playerctl --list-all ; return $((ret?ret:1))
+	fi
 }
 
 status () {


### PR DESCRIPTION
Discard the playerctl stderr when listing players.

This fixes a test failure when using glib 2.73.3.

playerctl with glib 2.73.3 emits a deprecation warning and that is
merged into the player list and the comparison with 'mpv' then fails.

When mpv is not present, the reason for that still needs to be printed,
so re-run the command when it failed or did not detect mpv is the player.

Please make a new minor release after merging this pull request.
