### PR TITLE
Fix cover art finding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 compile_commands.json
+.ccls-cache/
 mpris.so
 *.mpv.ipc.input.json
 *.mpv.ipc.output.json


### PR DESCRIPTION
This improves the way that `mpv-mpris` finds external cover art by doing it basically the exact same way that MPV does.