### PR TITLE
Ignore embedded thumbnail art when too large

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -289,7 +289,13 @@ static gchar* extract_embedded_art(AVFormatContext *context) {
     AVPacket *packet = NULL;
     for (unsigned int i = 0; i < context->nb_streams; i++) {
         if (context->streams[i]->disposition & AV_DISPOSITION_ATTACHED_PIC) {
-            packet = &context->streams[i]->attached_pic;
+            AVPacket *p = &context->streams[i]->attached_pic;
+
+            // Skip the thumbnail if the size is bigger than 25MiB to avoid crashes
+            if (p->size <= 25*0x100000) {
+                packet = p;
+                break;
+            }
         }
     }
     if (!packet) {


### PR DESCRIPTION
[This encode](https://nyaa.si/view/1316324) contains a ridiculously large embedded thumbnail art (4785x8529 png, 98.5MiB), which this script ends up passing as inline b64-encoded url.
This triggers a crash deep inside glibc which I'm not willing to investigate, since I value my sanity. 
Instead, just put a threshold on the size for an acceptable thumbnail art. 25MiB is already way bigger than it needs to be, but I verified it working for a ~37MiB thumbnail file.