### PR TITLE
Fix: simple shuffle pointer

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -679,7 +679,7 @@ static GVariant *get_property_player(G_GNUC_UNUSED GDBusConnection *connection,
 
     } else if (g_strcmp0(property_name, "Shuffle") == 0) {
         int shuffle;
-        mpv_get_property(ud->mpv, "playlist-shuffle", MPV_FORMAT_FLAG, &shuffle);
+        mpv_get_property(ud->mpv, "shuffle", MPV_FORMAT_FLAG, &shuffle);
         ret = g_variant_new_boolean(shuffle);
 
     } else if (g_strcmp0(property_name, "Metadata") == 0) {
@@ -769,7 +769,7 @@ static gboolean set_property_player(G_GNUC_UNUSED GDBusConnection *connection,
 
     } else if (g_strcmp0(property_name, "Shuffle") == 0) {
         int shuffle = g_variant_get_boolean(value);
-        mpv_set_property(ud->mpv, "playlist-shuffle", MPV_FORMAT_FLAG, &shuffle);
+        mpv_set_property(ud->mpv, "shuffle", MPV_FORMAT_FLAG, &shuffle);
 
     } else if (g_strcmp0(property_name, "Volume") == 0) {
         double volume = g_variant_get_double(value);
@@ -988,6 +988,11 @@ static void handle_property_change(const char *name, void *data, UserData *ud)
         prop_name = "LoopStatus";
         prop_value = g_variant_new_string(ud->loop_status);
 
+    } else if (g_strcmp0(name, "shuffle") == 0) {
+        int shuffle = *(int*)data;
+        prop_name = "Shuffle";
+        prop_value = g_variant_new_boolean(shuffle);
+
     } else if (g_strcmp0(name, "fullscreen") == 0) {
         gboolean *status = data;
         prop_name = "Fullscreen";
@@ -1102,6 +1107,7 @@ int mpv_open_cplugin(mpv_handle *mpv)
     mpv_observe_property(mpv, 0, "loop-file", MPV_FORMAT_STRING);
     mpv_observe_property(mpv, 0, "loop-playlist", MPV_FORMAT_STRING);
     mpv_observe_property(mpv, 0, "duration", MPV_FORMAT_INT64);
+    mpv_observe_property(mpv, 0, "shuffle", MPV_FORMAT_FLAG);
     mpv_observe_property(mpv, 0, "fullscreen", MPV_FORMAT_FLAG);
 
     // Run callback whenever there are events


### PR DESCRIPTION
mpv-mpris should be using the `shuffle` property to determine the shuffle state `playlist-shuffle` is a method not a property. `playlist-shuffle` does not return any value and simply "shuffles" the playlist structure.

*Per mpv source playlist.c*
```c
void playlist_shuffle(struct playlist *pl)
{
    for (int n = 0; n < pl->num_entries; n++)
        pl->entries[n]->original_index = n;
    mp_rand_state s = mp_rand_seed(0);
    for (int n = 0; n < pl->num_entries - 1; n++) {
        size_t j = mp_rand_in_range32(&s, n, pl->num_entries);
        MPSWAP(struct playlist_entry *, pl->entries[n], pl->entries[j]);
    }
    playlist_update_indexes(pl, 0, -1);
}
```

This  PR only fixes the pointer and adds shuffle to observe list to push PropertyChanged to mpris.

> [!NOTE]
>Why this fix is not enough:
>- Shuffle does not modify the current playlist. 
>- Shuffle only calls the playlist-shuffle on every loop of the playlist. 
>
>A more complete shuffle solution is provided in PR [119](https://github.com/hoyon/mpv-mpris/pull/119)

fixes: [113](https://github.com/hoyon/mpv-mpris/issues/113)