### PR TITLE
fix: remove redundant overwrite of media-title

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -410,7 +410,6 @@ static GVariant *create_metadata(UserData *ud)
     // initial value. Replaced with metadata value if available
     add_metadata_item_string(ud->mpv, &dict, "media-title", "xesam:title");
 
-    add_metadata_item_string(ud->mpv, &dict, "metadata/by-key/Title", "xesam:title");
     add_metadata_item_string(ud->mpv, &dict, "metadata/by-key/Album", "xesam:album");
     add_metadata_item_string(ud->mpv, &dict, "metadata/by-key/Genre", "xesam:genre");
 


### PR DESCRIPTION
The `xesam:title` should be handled upstream, as mpv already overwrites `media-title` when `metadata:title` exists, making the mpv-mpris overwrite redundant and potentially destructive, since mpv also supports `--force-media-title`.

By removing our overwrite, we align mpv-mpris with user expectations and support mpv's built-in title handling.

MPV's priority for media-title = force-media-title -> metadata:title -> filename

fixes: [114](https://github.com/hoyon/mpv-mpris/issues/114)