### PR TITLE
feat: External Track Art

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -236,8 +236,25 @@ static const char art_files[][20] = {
 static const int art_files_count = sizeof(art_files) / sizeof(art_files[0]);
 
 static gchar* try_get_local_art(mpv_handle *mpv, char *path)
-{
-    gchar *dirname = g_path_get_dirname(path), *out = NULL;
+{   
+    gchar *out = NULL;
+    const gchar *extensions[] = {".jpg", ".png", ".gif", ".bmp", NULL};
+
+    gchar *base = g_strndup(path, strrchr(path, '.') - path);
+    gchar *filename = NULL;
+    for (const char **ext = extensions; *ext; ++ext) {
+        filename = g_strdup_printf("%s%s", base, *ext);
+        if (g_file_test(filename, G_FILE_TEST_EXISTS)) {
+            out = path_to_uri(mpv, filename);
+            g_free(filename); filename = NULL;
+            g_free(base); base = NULL;
+            return out;
+        }
+    }
+    g_free(filename); filename = NULL;
+    g_free(base); base = NULL;
+
+    gchar *dirname = g_path_get_dirname(path);
     gboolean found = FALSE;
 
     for (int i = 0; i < art_files_count; i++) {


### PR DESCRIPTION
This will find local external coverart. ie `ASong.mp3` `ASong.jpg`

supported extensions in line with current builtins
- jpg
- png
- gif
- bmp

> [!NOTE]
> [PR123](https://github.com/hoyon/mpv-mpris/pull/123) expands on supported extensions. These two PRs collide.  [PR124](https://github.com/hoyon/mpv-mpris/pull/124) is a merge of the 123 and this.