### PR TITLE
feat/fix: coverart rework PR 121+123

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -215,46 +215,32 @@ static void add_metadata_uri(mpv_handle *mpv, GVariantDict *dict)
     mpv_free(path);
 }
 
-// Copied from https://github.com/videolan/vlc/blob/master/modules/meta_engine/folder.c
-static const char art_files[][20] = {
-    "Folder.jpg",           /* Windows */
-    "Folder.png",
-    "AlbumArtSmall.jpg",    /* Windows */
-    "AlbumArt.jpg",         /* Windows */
-    "Album.jpg",
-    ".folder.png",          /* KDE?    */
-    "cover.jpg",            /* rockbox */
-    "cover.png",
-    "cover.gif",
-    "front.jpg",
-    "front.png",
-    "front.gif",
-    "front.bmp",
-    "thumb.jpg",
+static const gchar *image_exts[] = {
+    "jpg", "png", "jpeg", "webp", "avif", "bmp", "svg", "gif", "heic", "heif",
+    "j2k", "jp2", "jxl", "qoi", "tga", "tif", "tiff", NULL
 };
 
-static const int art_files_count = sizeof(art_files) / sizeof(art_files[0]);
+static const gchar *coverart[] = {
+    "AlbumArt", "Album", "cover", "front", "AlbumArtSmall", "Folder",
+    ".folder", "thumb", NULL
+};
 
 static gchar* try_get_local_art(mpv_handle *mpv, char *path)
 {
-    gchar *dirname = g_path_get_dirname(path), *out = NULL;
-    gboolean found = FALSE;
+    gchar *out = NULL;
+    gchar *dirname = g_path_get_dirname(path);
 
-    for (int i = 0; i < art_files_count; i++) {
-        gchar *filename = g_build_filename(dirname, art_files[i], NULL);
-
-        if (g_file_test(filename, G_FILE_TEST_EXISTS)) {
-            out = path_to_uri(mpv, filename);
-            found = TRUE;
-        }
-
-        g_free(filename);
-
-        if (found) {
-            break;
+    for (const gchar **ext = image_exts; *ext; ++ext) {
+        for (const gchar **name = coverart; *name; ++name) {
+            gchar *filename = g_strdup_printf("%s/%s.%s", dirname, *name, *ext);
+            if (g_file_test(filename, G_FILE_TEST_EXISTS)) {
+                out = path_to_uri(mpv, filename);
+                g_free(filename); g_free(dirname);
+                return out;
+            }
+            g_free(filename);
         }
     }
-
     g_free(dirname);
     return out;
 }


### PR DESCRIPTION
Patches [PR121](https://github.com/hoyon/mpv-mpris/pull/121) and [PR123](https://github.com/hoyon/mpv-mpris/pull/123)

121: Added external song cover support (further expanded file type support with PR123)
123: realigned external album artwork to match upstream supported files+formats

fixes: [108](https://github.com/hoyon/mpv-mpris/issues/108)

>[!NOTE]
>Overlaps [PR103](https://github.com/hoyon/mpv-mpris/pull/103) *Addresses the same issue. Apparently 103 is broken.