### PR TITLE
Remove executable check for MPV_MPRIS_TEST_PLUGIN

### DIFF
--- a/test/env
+++ b/test/env
@@ -41,9 +41,8 @@ fi
 
 if [ -n "$MPV_MPRIS_TEST_PLUGIN" ] ; then
 	if [ ! -f "$MPV_MPRIS_TEST_PLUGIN" ] ||
-	   [ ! -r "$MPV_MPRIS_TEST_PLUGIN" ] ||
-	   [ ! -x "$MPV_MPRIS_TEST_PLUGIN" ] ; then
-		echo "$MPV_MPRIS_TEST_PLUGIN not an existing file with rx perms" >&2
+	   [ ! -r "$MPV_MPRIS_TEST_PLUGIN" ] ; then
+		echo "$MPV_MPRIS_TEST_PLUGIN not an existing file with read perms" >&2
 		exit 1
 	fi
 fi


### PR DESCRIPTION
It's not necessary for shared libraries to have the executable bit to be loaded.