### PR TITLE
Set CanPlay/CanPause based on mpv idle state

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -104,6 +104,7 @@ static const char *LOOP_PLAYLIST = "Playlist";
 static void setup_mpv_event_sources(UserData *ud);
 static gboolean can_go_next(UserData *ud);
 static gboolean can_go_previous(UserData *ud);
+static gboolean can_play_pause(UserData *ud);
 
 static gchar *string_to_utf8(gchar *maybe_utf8)
 {
@@ -729,10 +730,10 @@ static GVariant *get_property_player(G_GNUC_UNUSED GDBusConnection *connection,
         ret = g_variant_new_boolean(can_go_previous(ud));
 
     } else if (g_strcmp0(property_name, "CanPlay") == 0) {
-        ret = g_variant_new_boolean(TRUE);
+        ret = g_variant_new_boolean(can_play_pause(ud));
 
     } else if (g_strcmp0(property_name, "CanPause") == 0) {
-        ret = g_variant_new_boolean(TRUE);
+        ret = g_variant_new_boolean(can_play_pause(ud));
 
     } else if (g_strcmp0(property_name, "CanSeek") == 0) {
         ret = g_variant_new_boolean(TRUE);
@@ -893,6 +894,14 @@ static gboolean can_go_previous(UserData *ud)
     return ud->playlist_pos > 0;
 }
 
+static gboolean can_play_pause(UserData *ud)
+{
+    if (ud->idle) {
+        return FALSE;
+    }
+    return TRUE;
+}
+
 static GVariant * set_playback_status(UserData *ud)
 {
     if (ud->idle) {
@@ -914,6 +923,9 @@ static void set_stopped_status(UserData *ud)
 
   g_hash_table_insert(ud->changed_properties,
                       (gpointer)prop_name, prop_value);
+
+  g_hash_table_insert(ud->changed_properties,
+                      "CanPlay",  g_variant_new_boolean(FALSE));
 
   emit_property_changes(ud);
 }
@@ -1013,6 +1025,7 @@ static void handle_property_change(const char *name, void *data, UserData *ud)
     const char *prop_name = NULL;
     GVariant *prop_value = NULL;
     gboolean update_can_go_next_prev = FALSE;
+    gboolean update_can_play_pause = FALSE;
 
     if (g_strcmp0(name, "pause") == 0) {
         ud->paused = *(int*)data;
@@ -1023,6 +1036,7 @@ static void handle_property_change(const char *name, void *data, UserData *ud)
         ud->idle = *(int*)data;
         prop_name = "PlaybackStatus";
         prop_value = set_playback_status(ud);
+        update_can_play_pause = TRUE;
 
     } else if (g_strcmp0(name, "media-title") == 0 ||
                g_strcmp0(name, "duration") == 0) {
@@ -1114,6 +1128,14 @@ static void handle_property_change(const char *name, void *data, UserData *ud)
                             g_variant_new_boolean(can_go_next(ud)));
         g_hash_table_insert(ud->changed_properties, "CanGoPrevious",
                             g_variant_new_boolean(can_go_previous(ud)));
+    }
+
+    if (update_can_play_pause) {
+        g_hash_table_insert(ud->changed_properties, "CanPlay",
+                            g_variant_new_boolean(can_play_pause(ud)));
+        g_hash_table_insert(ud->changed_properties, "CanPause",
+                            g_variant_new_boolean(can_play_pause(ud)));
+
     }
 }
 


### PR DESCRIPTION
Hi there, I've made a small modification that solved a minor annoyance with my use case. 

When MPV is run as a background daemon such as with `jellyfin-mpv-shim`, the process is often in a stopped idle state with no video currently playing. 
Some MPRIS clients use the CanPlay property as an indicator to show/hide the media player controls. This commit makes it so than when mpv goes into the idle state, and the MPRIS PlaybackStatus is set to Stopped, CanPlay and CanPause are also set to `false`.
According to my interpretation of the [MPRIS specification](https://specifications.freedesktop.org/mpris/latest/Player_Interface.html#Property:CanPlay), I think this is the correct operation when MPV is not playing a video (but is running in the idle state). The spec says that the CanPlay and CanPause boolean properties should be set to reflect the state of the media player.  

I am not familiar with the code base, so I will in no way take offense if you want to ignore this PR or re-write with a different implementation. Just thought I would share what was working for me.

PS. I don't know anything about GLib, but I was somewhat confused when writing this about where in the code all the `GVariant`s created from calls to `g_variant_new_*()` are freed. I imagine there is some magic library-handled cleanup that I missed. Maybe that is a non-issue, but it made me think.