### PR TITLE
feat: instance pid with instanceRandom fallback

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -1230,7 +1230,7 @@ int mpv_open_cplugin(mpv_handle *mpv)
     mpv_get_property(mpv, "playlist-count", MPV_FORMAT_INT64, &ud.playlist_count);
     mpv_get_property(mpv, "playlist-pos", MPV_FORMAT_INT64, &ud.playlist_pos);
 
-    char *bus_name = build_bus_name(ud.client_name, FALSE);
+    char *bus_name = g_strdup_printf("org.mpris.MediaPlayer2.%s.instance%d", ud.client_name, getpid());
     g_main_context_push_thread_default(ctx);
     ud.bus_id = g_bus_own_name(G_BUS_TYPE_SESSION,
                                bus_name,

--- a/test/setup
+++ b/test/setup
@@ -64,7 +64,7 @@ wait_for () {
 
 playerctl_list_all_is_mpv () {
 	ret=0 ; player="$(playerctl --list-all 2> /dev/null)" || ret=$?
-	if [ $ret -ne 0 ] || [ "$player" != mpv ] ; then
+	if [ $ret -ne 0 ] || [[ "$player" != mpv.instance* ]] ; then
 		playerctl --list-all ; return $((ret?ret:1))
 	fi
 }
@@ -77,7 +77,7 @@ status () {
 mpris_quit () {
 	# playerctl does not yet support the MPRIS Quit API
 	# https://github.com/altdesktop/playerctl/issues/171
-	dbus-send --print-reply --dest=org.mpris.MediaPlayer2.mpv /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Quit
+	dbus-send --print-reply --dest=org.mpris.MediaPlayer2."$(playerctl --list-all 2> /dev/null | grep -E "^mpv.instance[0-9]*$")" /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Quit
 }
 
 


### PR DESCRIPTION
Different approach for [060bf16](https://github.com/hoyon/mpv-mpris/commit/060bf16b93f1bc506397299fd99b97b205aa3468)

Maintains the MPRIS mpv.instancePID while still supporting siloed instances like flatpack via the GBusNameLostCallback on_name_lost.

Caveats:
- Lost the singular .mpv all are now mpv.instancePID.
- First siloed instance will take the mpv.instance1 while the next siloed instance will fail to reserve the instance1 and will fallback to random generator.

fixes [52](https://github.com/hoyon/mpv-mpris/issues/52)