### PR TITLE
feat: support audio-client as identity

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -539,7 +539,12 @@ static GVariant *get_property_root(G_GNUC_UNUSED GDBusConnection *connection,
         ret = g_variant_new_boolean(FALSE);
 
     } else if (g_strcmp0(property_name, "Identity") == 0) {
-        ret = g_variant_new_string("mpv");
+        char *client_name = mpv_get_property_string(ud->mpv, "audio-client-name");
+        ret = g_variant_new_string(
+            (client_name && *client_name) ? client_name : "mpv"
+        );
+        if (client_name)
+            mpv_free(client_name);
 
     } else if (g_strcmp0(property_name, "DesktopEntry") == 0) {
         ret = g_variant_new_string("mpv");


### PR DESCRIPTION
## Behaviour
Adds support of using MPV property "audio-client-name" as Identity. Keeps default string "mpv" as fallback if property is undefined.

### Before
```bash
busctl --user get-property \   
                 org.mpris.MediaPlayer2.mpv.shellbeats \
                 /org/mpris/MediaPlayer2 \
                 org.mpris.MediaPlayer2 Identity
s "mpv"
```

### After
```bash
busctl --user get-property \   
                 org.mpris.MediaPlayer2.mpv.shellbeats \
                 /org/mpris/MediaPlayer2 \
                 org.mpris.MediaPlayer2 Identity
s "shellbeats"
```